### PR TITLE
Proper error handling when parsing Uint256 numbers greater 2^53-1

### DIFF
--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -306,7 +306,7 @@ proc scanInt(lexer: var JsonLexer): (uint64,string) =
     c = lexer.stream.peek()
     overflow = false
   const
-    spaceOkUpperBound = (result[0].high - 9) div 10
+    spaceOkUpperBound = (uint64.high - 9) div 10
 
   result[0] = uint64(ord(c) - ord('0'))
 
@@ -317,10 +317,10 @@ proc scanInt(lexer: var JsonLexer): (uint64,string) =
     else:
       let lsDgt = uint64(ord(c) - ord('0'))
       if spaceOkUpperBound < result[0] and
-         (result[0].high - lsDgt) div 10 < result[0]:
+          (uint64.high - lsDgt) div 10 < result[0]:
         overflow = true
         result[1] = $result[0] & $c
-        result[0] = result[0].high
+        result[0] = uint64.high
       else:
         result[0] = result[0] * 10 + lsDgt
     c = eatDigitAndPeek() # implicit auto-return


### PR DESCRIPTION
Note: On a NIM compiler version later than 1.2.16, the unit tests fails at _Json generic roundtrip tests_ -> _case objects_ ([somewhere here](https://github.com/status-im/nim-serialization/blob/9631fbd1c81c8b25ff8740df440ca7ba87fa6131/serialization/testing/generic_suite.nim#L148)) unless the compiler flag `-d:nimOldCaseObjects` is set. This happens also to the main branch.