### PR TITLE
rm TaintedString

### DIFF
--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -455,9 +455,6 @@ proc readValue*[T](r: var JsonReader, value: var T)
     value = r.lexer.strVal
     r.lexer.next()
 
-  elif value is TaintedString:
-    value = TaintedString r.readValue(string)
-
   elif value is seq[char]:
     r.requireToken tkString
     value.setLen(r.lexer.strVal.len)

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -192,9 +192,6 @@ proc writeValue*(w: var JsonWriter, value: auto) =
 
     append '"'
 
-  elif value is TaintedString:
-    writeValue(w, string value)
-
   elif value is bool:
     append if value: "true" else: "false"
 


### PR DESCRIPTION
In Nim 1.6, a `TaintedString` is a string:
```nim
type TaintedString* {.deprecated: "Deprecated since 1.5".} = string
```
so this has no effect.

In Nim 1.2 and Nim 1.4, it's a normal string unless `taintMode` is defined, which at least in `nimbus-eth2`, does not happen:
```nim
when taintMode:
  type TaintedString* = distinct string ## A distinct string type that
                                        ## is `tainted`:idx:, see `taint mode
                                        ## <manual_experimental.html#taint-mode>`_
                                        ## for details. It is an alias for
                                        ## ``string`` if the taint mode is not
                                        ## turned on.
```

Furthermore, the all the `TaintedString`/`string` conversions I found did no validity checking at all, just treated this as one more (in reality, nonexistent) roadbump to bulldoze through the type system. This includes all the couple dozen Status-maintained git submodules that `nimbus-eth2` uses.