### PR TITLE
Fix option serializing 

### DIFF
--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -418,7 +418,7 @@ func expectedFieldsBitmask*(TT: type): auto {.compileTime.} =
         enumAllSerializedFields
 
   const requiredWords =
-    (totalExpectedFields(T) + bitsPerWord - 1) div bitsPerWord
+    (totalSerializedFields(T) + bitsPerWord - 1) div bitsPerWord
 
   var res: array[requiredWords, uint]
 

--- a/json_serialization/std/options.nim
+++ b/json_serialization/std/options.nim
@@ -4,11 +4,13 @@ export options
 template writeObjectField*(w: var JsonWriter,
                            record: auto,
                            fieldName: static string,
-                           field: Option) =
+                           field: Option): bool =
   mixin writeObjectField
 
   if field.isSome:
     writeObjectField(w, record, fieldName, field.get)
+  else:
+    false
 
 proc writeValue*(writer: var JsonWriter, value: Option) =
   mixin writeValue

--- a/json_serialization/stew/results.nim
+++ b/json_serialization/stew/results.nim
@@ -7,11 +7,13 @@ export
 template writeObjectField*[T](w: var JsonWriter,
                               record: auto,
                               fieldName: static string,
-                              field: Result[T, void]) =
+                              field: Result[T, void]): bool =
   mixin writeObjectField
 
   if field.isOk:
     writeObjectField(w, record, fieldName, field.get)
+  else:
+    false
 
 proc writeValue*[T](writer: var JsonWriter, value: Result[T, void]) =
   mixin writeValue

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -148,7 +148,7 @@ template isStringLike(v: auto): bool = false
 template writeObjectField*[FieldType, RecordType](w: var JsonWriter,
                                                   record: RecordType,
                                                   fieldName: static string,
-                                                  field: FieldType) =
+                                                  field: FieldType): bool =
   mixin writeFieldIMPL, writeValue
 
   type
@@ -159,6 +159,7 @@ template writeObjectField*[FieldType, RecordType](w: var JsonWriter,
     w.writeValue(field)
   else:
     w.writeFieldIMPL(FieldTag[R, fieldName], field, record)
+  true
 
 proc writeValue*(w: var JsonWriter, value: auto) =
   mixin enumInstanceSerializedFields, writeValue
@@ -238,8 +239,8 @@ proc writeValue*(w: var JsonWriter, value: auto) =
     w.beginRecord RecordType
     value.enumInstanceSerializedFields(fieldName, field):
       mixin writeObjectField
-      writeObjectField(w, value, fieldName, field)
-      w.state = AfterField
+      if writeObjectField(w, value, fieldName, field):
+        w.state = AfterField
     w.endRecord()
 
   else:


### PR DESCRIPTION
Currently, an object with `a: none string, b: "Whatever"`
will serialize to:
`{,"b": "Whatever"}`

This fix seem to work, although not very elegant
I'm not familiar with this system, so please double check