### PR TITLE
use string value when encoding enums

### DIFF
--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -2,7 +2,7 @@
 
 import
   std/[tables, macros, strformat],
-  stew/enums, stew/shims/[enumutils, typetraits],
+  stew/[enums, objects], stew/shims/[enumutils, typetraits],
   faststreams/inputs, serialization/[formats, object_serialization, errors],
   "."/[format, types, lexer]
 

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -1,6 +1,5 @@
 import
   std/[json, typetraits],
-  stew/enums,
   faststreams/[outputs, textio], serialization,
   "."/[format, types]
 
@@ -216,11 +215,7 @@ proc writeValue*(w: var JsonWriter, value: auto) =
     append if value: "true" else: "false"
 
   elif value is enum:
-    case typeof(value).enumStyle
-    of EnumStyle.Numeric:
-      w.stream.writeText ord(value)
-    of EnumStyle.AssociatedStrings:
-      w.writeValue $value
+    w.writeValue $value
 
   elif value is range:
     when low(typeof(value)) < 0:

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -1,5 +1,6 @@
 import
   std/[json, typetraits],
+  stew/enums,
   faststreams/[outputs, textio], serialization,
   "."/[format, types]
 
@@ -215,7 +216,11 @@ proc writeValue*(w: var JsonWriter, value: auto) =
     append if value: "true" else: "false"
 
   elif value is enum:
-    w.stream.writeText ord(value)
+    case typeof(value).enumStyle
+    of EnumStyle.Numeric:
+      w.stream.writeText ord(value)
+    of EnumStyle.AssociatedStrings:
+      w.writeValue $value
 
   elif value is range:
     when low(typeof(value)) < 0:
@@ -258,4 +263,3 @@ proc toJson*(v: auto, pretty = false, typeAnnotations = false): string =
 template serializesAsTextInJson*(T: type[enum]) =
   template writeValue*(w: var JsonWriter, val: T) =
     w.writeValue $val
-

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -224,6 +224,12 @@ type EnumTestN = enum
   n3 = "ccc"
 EnumTestN.deserializeWithNormalizerInJson(nimIdentNormalize)
 
+type EnumTestO = enum
+  o1,
+  o2,
+  o3
+EnumTestO.deserializeWithNormalizerInJson(nimIdentNormalize)
+
 suite "toJson tests":
   test "encode primitives":
     check:
@@ -252,31 +258,34 @@ suite "toJson tests":
     Json.roundtripTest x0, "0"
     Json.roundtripTest x1, "1"
     Json.roundtripTest x2, "2"
+    check:
+      Json.decode("\"x0\"", EnumTestX) == x0
+      Json.decode("\"x1\"", EnumTestX) == x1
+      Json.decode("\"x2\"", EnumTestX) == x2
     expect UnexpectedValueError:
       discard Json.decode("3", EnumTestX)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"x0\"", EnumTestX)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"x1\"", EnumTestX)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"x2\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"X0\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"X1\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"X2\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"x_0\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"\"", EnumTestX)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"0\"", EnumTestX)
 
     Json.roundtripTest y1, "1"
     Json.roundtripTest y3, "3"
     Json.roundtripTest y4, "4"
     Json.roundtripTest y6, "6"
+    check:
+      Json.decode("\"y1\"", EnumTestY) == y1
+      Json.decode("\"y3\"", EnumTestY) == y3
+      Json.decode("\"y4\"", EnumTestY) == y4
+      Json.decode("\"y6\"", EnumTestY) == y6
     expect UnexpectedValueError:
       discard Json.decode("0", EnumTestY)
     expect UnexpectedValueError:
@@ -285,27 +294,19 @@ suite "toJson tests":
       discard Json.decode("5", EnumTestY)
     expect UnexpectedValueError:
       discard Json.decode("7", EnumTestY)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"y1\"", EnumTestY)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"y3\"", EnumTestY)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"y4\"", EnumTestY)
-    expect UnexpectedTokenError:
-      discard Json.decode("\"y6\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"Y1\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"Y3\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"Y4\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"Y6\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"y_1\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"\"", EnumTestY)
-    expect UnexpectedTokenError:
+    expect UnexpectedValueError:
       discard Json.decode("\"1\"", EnumTestY)
 
     Json.roundtripTest z1, "\"aaa\""
@@ -360,6 +361,28 @@ suite "toJson tests":
       discard Json.decode("\"\"", EnumTestN)
     expect UnexpectedValueError:
       discard Json.decode("\"\ud83d\udc3c\"", EnumTestN)
+
+    Json.roundtripTest o1, "0"
+    Json.roundtripTest o2, "1"
+    Json.roundtripTest o3, "2"
+    check:
+      Json.decode("\"o1\"", EnumTestO) == o1
+      Json.decode("\"o2\"", EnumTestO) == o2
+      Json.decode("\"o3\"", EnumTestO) == o3
+      Json.decode("\"o_1\"", EnumTestO) == o1
+      Json.decode("\"o_2\"", EnumTestO) == o2
+      Json.decode("\"o_3\"", EnumTestO) == o3
+    expect UnexpectedValueError:
+      discard Json.decode("\"O1\"", EnumTestO)
+    expect UnexpectedValueError:
+      discard Json.decode("\"O2\"", EnumTestO)
+    expect UnexpectedValueError:
+      discard Json.decode("\"O3\"", EnumTestO)
+    expect UnexpectedValueError:
+      discard Json.decode("\"_o1\"", EnumTestO)
+      discard Json.decode("\"\"", EnumTestO)
+    expect UnexpectedValueError:
+      discard Json.decode("\"\ud83d\udc3c\"", EnumTestO)
 
   test "simple objects":
     var s = Simple(x: 10, y: "test", distance: Meter(20))


### PR DESCRIPTION
Currently, we encode enum values always as the numeric value `ord(val)`. unless explicitly overridden using `serializesAsTextInJson` or with a custom `writeValue` implementation. Reduce verbosity by automatically doing that.