### PR TITLE
import `std/[enumutils, typetraits]` directly, not via stew/shims

### DIFF
--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -1,8 +1,8 @@
 {.experimental: "notnil".}
 
 import
-  std/[tables, macros, strformat],
-  stew/[enums, objects], stew/shims/[enumutils, typetraits],
+  std/[enumutils, tables, macros, strformat, typetraits],
+  stew/[enums, objects],
   faststreams/inputs, serialization/[formats, object_serialization, errors],
   "."/[format, types, lexer]
 


### PR DESCRIPTION
Since https://github.com/status-im/nim-json-serialization/commit/3390fa3142c5f1bf81e0947f871efc3f1043ad43 removes pre-1.6 support, all supported Nim versions trigger

https://github.com/status-im/nim-stew/blob/master/stew/shims/enumutils.nim
```nim
when (NimMajor, NimMinor) > (1, 4):
  import std/enumutils
  export enumutils

else:  # Copy from `std/enumutils`
  # .. until end of module ...
```
and https://github.com/status-im/nim-stew/blob/master/stew/shims/typetraits.nim
```nim
import std/typetraits
export typetraits

when (NimMajor, NimMinor) < (1, 6):  # Copy from `std/typetraits`
  # ... until end of module ...
```

So it's effectively equivalent to just import `std/enumutils` and `std/typetraits` directly.