### PR TITLE
add `{.raises.}` annotation to `writeValue`

### DIFF
--- a/json_serialization/std/net.nim
+++ b/json_serialization/std/net.nim
@@ -5,7 +5,8 @@ import
 export
   net, common
 
-proc writeValue*(writer: var JsonWriter, value: IpAddress) =
+proc writeValue*(
+    writer: var JsonWriter, value: IpAddress) {.raises: [IOError].} =
   writeValue(writer, $value)
 
 proc readValue*(reader: var JsonReader, value: var IpAddress) =
@@ -21,15 +22,16 @@ template writeValue*(writer: var JsonWriter, value: ValidIpAddress) =
 template readValue*(reader: var JsonReader, value: var ValidIpAddress) =
   readValue reader, IpAddress(value)
 
-proc writeValue*(writer: var JsonWriter, value: Port) =
+proc writeValue*(
+    writer: var JsonWriter, value: Port) {.raises: [IOError].} =
   writeValue(writer, uint16 value)
 
 proc readValue*(reader: var JsonReader, value: var Port) =
   value = Port reader.readValue(uint16)
 
-proc writeValue*(writer: var JsonWriter, value: AddressFamily) =
+proc writeValue*(
+    writer: var JsonWriter, value: AddressFamily) {.raises: [IOError].} =
   writeValue(writer, $value)
 
 proc readValue*(reader: var JsonReader, value: var AddressFamily) =
   value = parseEnum[AddressFamily](reader.readValue(string))
-

--- a/json_serialization/std/options.nim
+++ b/json_serialization/std/options.nim
@@ -12,7 +12,7 @@ template writeObjectField*(w: var JsonWriter,
   else:
     false
 
-proc writeValue*(writer: var JsonWriter, value: Option) =
+proc writeValue*(writer: var JsonWriter, value: Option) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isSome:

--- a/json_serialization/std/sets.nim
+++ b/json_serialization/std/sets.nim
@@ -4,7 +4,7 @@ export sets
 type
   SetType = OrderedSet | HashSet | set
 
-proc writeValue*(writer: var JsonWriter, value: SetType) =
+proc writeValue*(writer: var JsonWriter, value: SetType) {.raises: [IOError].} =
   writer.writeIterable value
 
 proc readValue*(reader: var JsonReader, value: var SetType) =
@@ -12,4 +12,3 @@ proc readValue*(reader: var JsonReader, value: var SetType) =
   value = init SetType
   for elem in readArray(reader, ElemType):
     value.incl elem
-

--- a/json_serialization/std/tables.nim
+++ b/json_serialization/std/tables.nim
@@ -4,7 +4,8 @@ export tables
 type
   TableType = OrderedTable | Table
 
-proc writeValue*(writer: var JsonWriter, value: TableType) =
+proc writeValue*(
+    writer: var JsonWriter, value: TableType) {.raises: [IOError].} =
   writer.beginRecord()
   for key, val in value:
     writer.writeField $key, val

--- a/json_serialization/stew/results.nim
+++ b/json_serialization/stew/results.nim
@@ -15,7 +15,8 @@ template writeObjectField*[T](w: var JsonWriter,
   else:
     false
 
-proc writeValue*[T](writer: var JsonWriter, value: Result[T, void]) =
+proc writeValue*[T](
+    writer: var JsonWriter, value: Result[T, void]) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isOk:

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -32,7 +32,7 @@ proc init*(W: type JsonWriter, stream: OutputStream,
 
 proc beginRecord*(w: var JsonWriter, T: type)
 proc beginRecord*(w: var JsonWriter)
-proc writeValue*(w: var JsonWriter, value: auto)
+proc writeValue*(w: var JsonWriter, value: auto) {.gcsafe, raises: [IOError].}
 
 template append(x: untyped) =
   write w.stream, x
@@ -65,7 +65,8 @@ proc writeFieldName*(w: var JsonWriter, name: string) =
 
   w.state = RecordExpected
 
-proc writeField*(w: var JsonWriter, name: string, value: auto) =
+proc writeField*(
+    w: var JsonWriter, name: string, value: auto) {.raises: [IOError].} =
   mixin writeValue
 
   w.writeFieldName(name)
@@ -161,7 +162,7 @@ template writeObjectField*[FieldType, RecordType](w: var JsonWriter,
     w.writeFieldIMPL(FieldTag[R, fieldName], field, record)
   true
 
-proc writeValue*(w: var JsonWriter, value: auto) =
+proc writeValue*(w: var JsonWriter, value: auto) {.gcsafe, raises: [IOError].} =
   mixin enumInstanceSerializedFields, writeValue
 
   when value is JsonNode:

--- a/tests/test_json_flavor.nim
+++ b/tests/test_json_flavor.nim
@@ -5,7 +5,8 @@ import
 
 Json.createFlavor StringyJson
 
-proc writeValue*(w: var JsonWriter[StringyJson], val: SomeInteger) =
+proc writeValue*(
+    w: var JsonWriter[StringyJson], val: SomeInteger) {.raises: [IOError].} =
   writeValue(w, $val)
 
 proc readValue*(r: var JsonReader[StringyJson], v: var SomeSignedInt) =
@@ -38,4 +39,3 @@ except SerializationError as err:
   quit 1
 
 echo "Decoded: ", decoded
-


### PR DESCRIPTION
Tag `writeValue` overrides with `{.raises: [IOError].}`.

The override in `writer.nim` also needs `gcsafe` to support recursion in Nim 2.0.