### PR TITLE
fix: amend incorrect int bound check

### DIFF
--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -187,7 +187,7 @@ proc readJsonNodeField(r: var JsonReader, field: var JsonNode)
   field = r.parseJsonNode()
 
 proc parseJsonNode(r: var JsonReader): JsonNode =
-  const maxIntValue = BiggestInt.high.uint64 + 1
+  const maxIntValue: uint64 = BiggestInt.high.uint64 + 1
 
   case r.lexer.tok
   of tkCurlyLe:

--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -589,13 +589,11 @@ proc readValue*[T](r: var JsonReader, value: var T)
 
   elif value is SomeInteger:
     type TargetType = type(value)
-    let maxValidValue = maxAbsValue(TargetType)
+    const maxValidValue = maxAbsValue(TargetType)
     let isNegative = tok == tkNegativeInt
+    let maxIntValue = if isNegative: maxValidValue else: maxValidValue - 1
 
-    if not isNegative:
-      maxValidValue -= 1
-
-    if r.lexer.absIntVal > maxValidValue:
+    if r.lexer.absIntVal > maxIntValue:
       r.raiseIntOverflow r.lexer.absIntVal, isNegative
 
     case tok
@@ -603,7 +601,7 @@ proc readValue*[T](r: var JsonReader, value: var T)
       value = TargetType(r.lexer.absIntVal)
     of tkNegativeInt:
       when value is SomeSignedInt:
-        if r.lexer.absIntVal == maxValidValue:
+        if r.lexer.absIntVal == maxIntValue:
           # We must handle this as a special case because it would be illegal
           # to convert a value like 128 to int8 before negating it. The max
           # int8 value is 127 (while the minimum is -128).

--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -592,7 +592,7 @@ proc readValue*[T](r: var JsonReader, value: var T)
     const maxValidValue = maxAbsValue(TargetType)
 
     let isNegative = tok == tkNegativeInt
-    if r.lexer.absIntVal > maxValidValue + uint64(isNegative):
+    if r.lexer.absIntVal > maxValidValue - uint64(not isNegative):
       r.raiseIntOverflow r.lexer.absIntVal, isNegative
 
     case tok

--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -589,10 +589,13 @@ proc readValue*[T](r: var JsonReader, value: var T)
 
   elif value is SomeInteger:
     type TargetType = type(value)
-    const maxValidValue = maxAbsValue(TargetType)
-
+    let maxValidValue = maxAbsValue(TargetType)
     let isNegative = tok == tkNegativeInt
-    if r.lexer.absIntVal > maxValidValue - uint64(not isNegative):
+
+    if not isNegative:
+      maxValidValue -= 1
+
+    if r.lexer.absIntVal > maxValidValue:
       r.raiseIntOverflow r.lexer.absIntVal, isNegative
 
     case tok

--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -584,7 +584,7 @@ proc readValue*[T](r: var JsonReader, value: var T)
     type TargetType = type(value)
     let
       isNegative = tok == tkNegativeInt
-      maxValidAbsValue =
+      maxValidAbsValue: uint64 =
         if isNegative:
           TargetType.high.uint64 + 1
         else:

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -657,26 +657,26 @@ suite "toJson tests":
       discard Json.decode(jsonValue, BiggestUint, mode = Portable)
 
   test "max signed value":
-    let intVal = int64.high
+    let intVal = BiggestInt.high
     let validJsonValue = Json.encode(intVal)
     let invalidJsonValue = "9223372036854775808"
     check:
       validJsonValue == "9223372036854775807"
-      Json.decode(validJsonValue, int64) == intVal
+      Json.decode(validJsonValue, BiggestInt) == intVal
 
     expect IntOverflowError:
-      discard Json.decode(invalidJsonValue, int64)
+      discard Json.decode(invalidJsonValue, BiggestInt)
 
   test "min signed value":
-    let intVal = int64.low
+    let intVal = BiggestInt.low
     let validJsonValue = Json.encode(intVal)
     let invalidJsonValue = "-9223372036854775809"
     check:
       validJsonValue == "-9223372036854775808"
-      Json.decode(validJsonValue, int64) == intVal
+      Json.decode(validJsonValue, BiggestInt) == intVal
 
     expect IntOverflowError:
-      discard Json.decode(invalidJsonValue, int64)
+      discard Json.decode(invalidJsonValue, BiggestInt)
 
   test "Unusual field names":
     let r = HasUnusualFieldNames(`type`: "uint8", renamedField: "field")

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -656,6 +656,28 @@ suite "toJson tests":
     expect JsonReaderError:
       discard Json.decode(jsonValue, uint64, mode = Portable)
 
+  test "max signed value":
+    let intVal = int64.high
+    let validJsonValue = Json.encode(intVal)
+    let invalidJsonValue = "9223372036854775808"
+    check:
+      validJsonValue == "9223372036854775807"
+      Json.decode(validJsonValue, int64) == intVal
+
+    expect IntOverflowError:
+      discard Json.decode(invalidJsonValue, int64)
+
+  test "min signed value":
+    let intVal = int64.low
+    let validJsonValue = Json.encode(intVal)
+    let invalidJsonValue = "-9223372036854775809"
+    check:
+      validJsonValue == "-9223372036854775808"
+      Json.decode(validJsonValue, int64) == intVal
+
+    expect IntOverflowError:
+      discard Json.decode(invalidJsonValue, int64)
+
   test "Unusual field names":
     let r = HasUnusualFieldNames(`type`: "uint8", renamedField: "field")
     check:

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -647,14 +647,14 @@ suite "toJson tests":
       """
 
   test "max unsigned value":
-    var uintVal = not uint64(0)
+    var uintVal = not BiggestUint(0)
     let jsonValue = Json.encode(uintVal)
     check:
       jsonValue == "18446744073709551615"
-      Json.decode(jsonValue, uint64) == uintVal
+      Json.decode(jsonValue, BiggestUint) == uintVal
 
     expect JsonReaderError:
-      discard Json.decode(jsonValue, uint64, mode = Portable)
+      discard Json.decode(jsonValue, BiggestUint, mode = Portable)
 
   test "max signed value":
     let intVal = int64.high


### PR DESCRIPTION
int64 numbers range from `-9,223,372,036,854,775,808` to `9,223,372,036,854,775,807`.

When checking if an int64 is in a valid range, we have to check whether its absolute value is smaller or equal than `9,223,372,036,854,775,808` for negative numbers, and smaller or equal than `9,223,372,036,854,775,807` for positive numbers.

Without this fix, `9,223,372,036,854,775,808` is taken as a valid int64 number which is not.