### PR TITLE
Basic support for Json flavours without default object serialization

### DIFF
--- a/json_serialization.nim
+++ b/json_serialization.nim
@@ -3,4 +3,3 @@ import
 
 export
   serialization, format, reader, writer
-

--- a/json_serialization/format.nim
+++ b/json_serialization/format.nim
@@ -8,3 +8,32 @@ template supports*(_: type Json, T: type): bool =
   # The JSON format should support every type
   true
 
+template flavorUsesAutomaticObjectSerialization*(T: type DefaultFlavor): bool = true
+template flavorOmitsOptionalFields*(T: type DefaultFlavor): bool = false
+template flavorRequiresAllFields*(T: type DefaultFlavor): bool = false
+template flavorAllowsUnknownFields*(T: type DefaultFlavor): bool = false
+
+# We create overloads of these traits to force the mixin treatment of the symbols
+type DummyFlavor* = object
+template flavorUsesAutomaticObjectSerialization*(T: type DummyFlavor): bool = true
+template flavorOmitsOptionalFields*(T: type DummyFlavor): bool = false
+template flavorRequiresAllFields*(T: type DummyFlavor): bool = false
+template flavorAllowsUnknownFields*(T: type DummyFlavor): bool = false
+
+template createJsonFlavor*(FlavorName: untyped,
+                           mimeTypeValue = "application/json",
+                           automaticObjectSerialization = false,
+                           requireAllFields = true,
+                           omitOptionalFields = true,
+                           allowUnknownFields = true) {.dirty.} =
+  type FlavorName* = object
+
+  template Reader*(T: type FlavorName): type = Reader(Json, FlavorName)
+  template Writer*(T: type FlavorName): type = Writer(Json, FlavorName)
+  template PreferredOutputType*(T: type FlavorName): type = string
+  template mimeType*(T: type FlavorName): string = mimeTypeValue
+
+  template flavorUsesAutomaticObjectSerialization*(T: type FlavorName): bool = automaticObjectSerialization
+  template flavorOmitsOptionalFields*(T: type FlavorName): bool = omitOptionalFields
+  template flavorRequiresAllFields*(T: type FlavorName): bool = requireAllFields
+  template flavorAllowsUnknownFields*(T: type FlavorName): bool = allowUnknownFields

--- a/json_serialization/std/options.nim
+++ b/json_serialization/std/options.nim
@@ -13,11 +13,12 @@ template writeObjectField*(w: var JsonWriter,
     false
 
 proc writeValue*(writer: var JsonWriter, value: Option) {.raises: [IOError].} =
-  mixin writeValue
+  mixin writeValue, flavorOmitsOptionalFields
+  type Flavor = JsonWriter.Flavor
 
   if value.isSome:
     writer.writeValue value.get
-  else:
+  elif not flavorOmitsOptionalFields(Flavor):
     writer.writeValue JsonString("null")
 
 proc readValue*[T](reader: var JsonReader, value: var Option[T]) =

--- a/json_serialization/stew/results.nim
+++ b/json_serialization/stew/results.nim
@@ -17,11 +17,12 @@ template writeObjectField*[T](w: var JsonWriter,
 
 proc writeValue*[T](
     writer: var JsonWriter, value: Result[T, void]) {.raises: [IOError].} =
-  mixin writeValue
+  mixin writeValue, flavorOmitsOptionalFields
+  type Flavor = JsonWriter.Flavor
 
   if value.isOk:
     writer.writeValue value.get
-  else:
+  elif not flavorOmitsOptionalFields(Flavor):
     writer.writeValue JsonString("null")
 
 proc readValue*[T](reader: var JsonReader, value: var Result[T, void]) =

--- a/json_serialization/types.nim
+++ b/json_serialization/types.nim
@@ -20,4 +20,3 @@ const
 
 template `==`*(lhs, rhs: JsonString): bool =
   string(lhs) == string(rhs)
-

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -1,4 +1,3 @@
 import
   test_lexer,
   test_serialization
-

--- a/tests/test_lexer.nim
+++ b/tests/test_lexer.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   unittest,
   ../json_serialization/lexer, ./utils

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -1,14 +1,12 @@
-import
-  strutils
+import strutils
 
-# `dedent` exists in newer nim version
-# and doesn't behave the same
-proc test_dedent*(s: string): string =
-  var s = s.strip(leading = false)
-  var minIndent = high(int)
+# `dedent` exists in newer Nim version and doesn't behave the same
+func test_dedent*(s: string): string =
+  var
+    s = s.strip(leading = false)
+    minIndent = high(int)
   for l in s.splitLines:
     let indent = count(l, ' ')
     if indent == 0: continue
     if indent < minIndent: minIndent = indent
-  result = s.unindent(minIndent)
-
+  s.unindent(minIndent)


### PR DESCRIPTION
Other changes:

* Migrate many procs accepting JsonReader to JsonLexer in order to reduce the number of generic instantiations and the resulting code bloat