### PR TITLE
Deconvolute optional fields writer

### DIFF
--- a/json_serialization/format.nim
+++ b/json_serialization/format.nim
@@ -21,7 +21,7 @@ template supports*(_: type Json, T: type): bool =
   true
 
 template flavorUsesAutomaticObjectSerialization*(T: type DefaultFlavor): bool = true
-template flavorOmitsOptionalFields*(T: type DefaultFlavor): bool = false
+template flavorOmitsOptionalFields*(T: type DefaultFlavor): bool = true
 template flavorRequiresAllFields*(T: type DefaultFlavor): bool = false
 template flavorAllowsUnknownFields*(T: type DefaultFlavor): bool = false
 template flavorSkipNullFields*(T: type DefaultFlavor): bool = false

--- a/json_serialization/std/options.nim
+++ b/json_serialization/std/options.nim
@@ -10,25 +10,15 @@
 import std/options, ../../json_serialization/[reader, writer, lexer]
 export options
 
-template writeObjectField*(w: var JsonWriter,
-                           record: auto,
-                           fieldName: static string,
-                           field: Option): bool =
-  mixin writeObjectField
-
-  if field.isSome:
-    writeObjectField(w, record, fieldName, field.get)
-  else:
-    false
+template shouldWriteObjectField*(field: Option): bool =
+  field.isSome
 
 proc writeValue*(writer: var JsonWriter, value: Option) {.raises: [IOError].} =
-  mixin writeValue, flavorOmitsOptionalFields
-  type Flavor = JsonWriter.Flavor
+  mixin writeValue
 
   if value.isSome:
     writer.writeValue value.get
-  elif not flavorOmitsOptionalFields(Flavor) or 
-      writer.nesting != JsonNesting.WriteObject:
+  else:
     writer.writeValue JsonString("null")
 
 proc readValue*[T](reader: var JsonReader, value: var Option[T]) =

--- a/json_serialization/stew/results.nim
+++ b/json_serialization/stew/results.nim
@@ -13,26 +13,16 @@ import
 export
   results
 
-template writeObjectField*[T](w: var JsonWriter,
-                              record: auto,
-                              fieldName: static string,
-                              field: Result[T, void]): bool =
-  mixin writeObjectField
-
-  if field.isOk:
-    writeObjectField(w, record, fieldName, field.get)
-  else:
-    false
+template shouldWriteObjectField*[T](field: Result[T, void]): bool =
+  field.isOk
 
 proc writeValue*[T](
     writer: var JsonWriter, value: Result[T, void]) {.raises: [IOError].} =
-  mixin writeValue, flavorOmitsOptionalFields
-  type Flavor = JsonWriter.Flavor
+  mixin writeValue
 
   if value.isOk:
     writer.writeValue value.get
-  elif not flavorOmitsOptionalFields(Flavor) or
-      writer.nesting != JsonNesting.WriteObject:
+  else:
     writer.writeValue JsonString("null")
 
 proc readValue*[T](reader: var JsonReader, value: var Result[T, void]) =

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -988,7 +988,7 @@ suite "Custom parser tests":
     check dData.name == "FancyUInt"
     check dData.data.uint == 12345u
     check customVisit.entry == JsonValueKind.String
-    
+
   test "Parser on text blob with embedded quote (backlash escape support)":
     customVisit = TokenRegistry.default
 

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -13,11 +13,20 @@ import
   ../json_serialization/std/options,
   ../json_serialization
 
+type
+  ObjectWithOptionalFields = object
+    a: Opt[int]
+    b: Option[string]
+    c: int
+
 createJsonFlavor YourJson,
   omitOptionalFields = false
 
 createJsonFlavor MyJson,
   omitOptionalFields = true
+
+ObjectWithOptionalFields.useDefaultSerializationIn YourJson
+ObjectWithOptionalFields.useDefaultSerializationIn MyJson
 
 suite "Test writer":
   test "stdlib option top level some YourJson":
@@ -99,3 +108,28 @@ suite "Test writer":
     var val = [Opt.some(123), Opt.none(int), Opt.some(777)]
     let json = MyJson.encode(val)
     check json == "[123,null,777]"
+
+  test "object with optional fields":
+    let x = ObjectWithOptionalFields(
+      a: Opt.some(123),
+      b: some("nano"),
+      c: 456,
+    )
+
+    let y = ObjectWithOptionalFields(
+      a: Opt.none(int),
+      b: none(string),
+      c: 999,
+    )
+
+    let u = YourJson.encode(x)
+    check u.string == """{"a":123,"b":"nano","c":456}"""
+
+    let v = YourJson.encode(y)
+    check v.string == """{"a":null,"b":null,"c":999}"""
+
+    let xx = MyJson.encode(x)
+    check xx.string == """{"a":123,"b":"nano","c":456}"""
+
+    let yy = MyJson.encode(y)
+    check yy.string == """{"c":999}"""


### PR DESCRIPTION
Thanks to @etan-status suggestion in https://github.com/status-im/nimbus-eth2/pull/5759. 
Now the convoluted optional fields writer is less convoluted.
This PR also fix a bug when `omitOptionalFields` set to `false`, it still not producing optional fields.