### PR TITLE
avoid `XDeclaredButNotUsed` when no field `isnot JsonVoid`

### DIFF
--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -198,14 +198,13 @@ proc writeRecordValue*(w: var JsonWriter, value: auto)
   mixin enumInstanceSerializedFields, writeObjectField
   mixin flavorOmitsOptionalFields, shouldWriteObjectField
 
-  type
-    Writer = typeof w
-    Flavor = Writer.Flavor
-
   type RecordType = type value
   w.beginRecord RecordType
   value.enumInstanceSerializedFields(fieldName, fieldValue):
     when fieldValue isnot JsonVoid:
+      type
+        Writer = typeof w
+        Flavor = Writer.Flavor
       when flavorOmitsOptionalFields(Flavor):
         if shouldWriteObjectField(fieldValue):
           writeObjectField(w, value, fieldName, fieldValue)


### PR DESCRIPTION
Move the type definitions for `Writer` and `Flavor` closer to their usage to avoid verbose hints when they are never used in an invocation.