### PR TITLE
extend automatic serialization support for `distinct` in Nim 2

### DIFF
--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -353,7 +353,7 @@ proc writeValue*(w: var JsonWriter, value: auto) {.gcsafe, raises: [IOError].} =
   elif value is (seq or array or openArray):
     w.writeArray(value)
 
-  elif value is (object or tuple):
+  elif value is (distinct or object or tuple):
     mixin flavorUsesAutomaticObjectSerialization
 
     type Flavor = JsonWriter.Flavor
@@ -364,7 +364,10 @@ proc writeValue*(w: var JsonWriter, value: auto) {.gcsafe, raises: [IOError].} =
       const typeName = typetraits.name(type value)
       {.error: "Please override writeValue for the " & typeName & " type (or import the module where the override is provided)".}
 
-    writeRecordValue(w, value)
+    when value is distinct:
+      writeRecordValue(w, distinctBase(value, recursive = false))
+    else:
+      writeRecordValue(w, value)
   else:
     const typeName = typetraits.name(value.type)
     {.fatal: "Failed to convert to JSON an unsupported type: " & typeName.}


### PR DESCRIPTION
In Nim 2, `distinct` values no longer match `value is object` but need to be checked separately with `value is distinct`. The underlying type can be unwrapped with `distinctBase` to inspect whether this is a value of type `distinct object` or `distinct` something-else.