### PR TITLE
fix stylecheck for BiggestUInt

### DIFF
--- a/json_serialization/reader_desc.nim
+++ b/json_serialization/reader_desc.nim
@@ -60,7 +60,7 @@ type
 
   IntOverflowError* = object of JsonReaderError
     isNegative: bool
-    absIntVal: BiggestUint
+    absIntVal: BiggestUInt
 
 Json.setReader JsonReader
 
@@ -129,7 +129,7 @@ template raiseUnexpectedValue*(r: JsonReader, msg: string) =
   raiseUnexpectedValue(r.lex, msg)
 
 func raiseIntOverflow*(
-    lex: JsonLexer, absIntVal: BiggestUint, isNegative: bool)
+    lex: JsonLexer, absIntVal: BiggestUInt, isNegative: bool)
     {.noreturn, raises: [JsonReaderError].} =
   var ex = new IntOverflowError
   ex.assignLineNumber(lex)
@@ -137,7 +137,7 @@ func raiseIntOverflow*(
   ex.isNegative = isNegative
   raise ex
 
-template raiseIntOverflow*(r: JsonReader, absIntVal: BiggestUint, isNegative: bool) =
+template raiseIntOverflow*(r: JsonReader, absIntVal: BiggestUInt, isNegative: bool) =
   raiseIntOverflow(r.lex, absIntVal, isNegative)
 
 func raiseUnexpectedField*(

--- a/tests/test_reader.nim
+++ b/tests/test_reader.nim
@@ -142,8 +142,9 @@ suite "JsonReader basic test":
   test "readValue":
     try:
       var r = toReader jsonText3
-      var val: MasterReader
-      r.readValue(val)
+      var valOrig: MasterReader
+      r.readValue(valOrig)
+      let val = valOrig
       check:
         val.one == JsonString("[1,true,null]")
         val.two.num == 123

--- a/tests/test_reader.nim
+++ b/tests/test_reader.nim
@@ -144,6 +144,7 @@ suite "JsonReader basic test":
       var r = toReader jsonText3
       var valOrig: MasterReader
       r.readValue(valOrig)
+      # workaround for https://github.com/nim-lang/Nim/issues/24274
       let val = valOrig
       check:
         val.one == JsonString("[1,true,null]")

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -678,14 +678,14 @@ suite "toJson tests":
       """
 
   test "max unsigned value":
-    var uintVal = not BiggestUint(0)
+    var uintVal = not BiggestUInt(0)
     let jsonValue = Json.encode(uintVal)
     check:
       jsonValue == "18446744073709551615"
-      Json.decode(jsonValue, BiggestUint) == uintVal
+      Json.decode(jsonValue, BiggestUInt) == uintVal
 
     expect JsonReaderError:
-      discard Json.decode(jsonValue, BiggestUint, flags = {JsonReaderFlag.portableInt})
+      discard Json.decode(jsonValue, BiggestUInt, flags = {JsonReaderFlag.portableInt})
 
   test "max signed value":
     let intVal = BiggestInt.high


### PR DESCRIPTION
As described in https://github.com/nim-lang/Nim/issues/24269, stylecheck has a bug where it doesn't check the usage of symbols from the standard library. The tests for this library [enable --styleCheck:error](https://github.com/status-im/nim-json-serialization/blob/ab1a061756bb6fc2e0f98cb57852f2bb0c6f9772/json_serialization.nimble#L29), so the style for stdlib symbols is fixed. In this library the only mismatching usage seems to be `BiggestUInt`.