### PR TITLE
check length before converting to range type

### DIFF
--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -10,7 +10,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "json_serialization"
-version       = "0.2.8"
+version       = "0.2.9"
 author        = "Status Research & Development GmbH"
 description   = "Flexible JSON serialization not relying on run-time type information"
 license       = "Apache License 2.0"

--- a/json_serialization/reader_impl.nim
+++ b/json_serialization/reader_impl.nim
@@ -312,11 +312,11 @@ proc readValue*[T](r: var JsonReader, value: var T)
   elif value is array:
     type IDX = typeof low(value)
     r.parseArray(idx):
-      let i = IDX(idx + low(value).int)
-      if i <= high(value):
-        # TODO: dont's ask. this makes the code compile
-        if false: value[i] = value[i]
+      if idx < value.len:
+        let i = IDX(idx + low(value).int)
         readValue(r, value[i])
+      else:
+        r.raiseUnexpectedValue("Too many items for " & $(typeof(value)))
 
   elif value is (object or tuple):
     mixin flavorUsesAutomaticObjectSerialization

--- a/tests/test_reader.nim
+++ b/tests/test_reader.nim
@@ -211,3 +211,12 @@ suite "JsonReader basic test":
 
     var z = toReaderNullFields("""{"something":null,"bool":999,"string":100}""")
     check execReadObject(z) == 2
+
+  test "readValue of array":
+    var r = toReader "[false, true, false]"
+    check r.readValue(array[3, bool]) == [false, true, false]
+
+  test "readValue of array error":
+    var r = toReader "[false, true, false]"
+    expect JsonReaderError:
+      discard r.readValue(array[2, bool])


### PR DESCRIPTION
The index type of an array is a `range` meaning that converting an out-of-bounds value to it will raise a `Defect`.

This PR fixes the defect but does nothing for arrays which are not "full" - probably, this should become an error.