### PR TITLE
chore: define version for dependencies

### DIFF
--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -17,9 +17,9 @@ license       = "Apache License 2.0"
 skipDirs      = @["tests", "fuzzer"]
 
 requires "nim >= 1.6.0",
-         "serialization",
-         "stew",
-         "results"
+         "serialization >= 0.2.0 & < 0.3.0",
+         "stew >= 0.2.0 & < 0.3.0",
+         "results >= 0.5.0 & < 0.6.0"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)


### PR DESCRIPTION
The dependencies are defined in Nimble without specifying versions, which is problematic as it can break dependency resolution for projects that rely on this library.

This is the case with the last version of [nim-stew](https://github.com/status-im/nim-stew/releases/tag/v0.4.0).