### PR TITLE
fix reading of empty object

### DIFF
--- a/json_serialization/format.nim
+++ b/json_serialization/format.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -1,11 +1,13 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [], gcsafe.}
 
 import
   std/[json, unicode],
@@ -71,8 +73,6 @@ type
     lineStartPos: int
     tokenStart: int
     depthLimit: int
-
-{.push gcsafe, raises: [].}
 
 # ------------------------------------------------------------------------------
 # Private helpers

--- a/json_serialization/pkg/results.nim
+++ b/json_serialization/pkg/results.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   pkg/results, ../../json_serialization/[reader, writer, lexer]
 
@@ -25,7 +27,8 @@ proc writeValue*[T](
   else:
     writer.writeValue JsonString("null")
 
-proc readValue*[T](reader: var JsonReader, value: var Result[T, void]) =
+proc readValue*[T](reader: var JsonReader, value: var Result[T, void]) {.
+      raises: [IOError, SerializationError].} =
   mixin readValue
 
   if reader.tokKind == JsonValueKind.Null:

--- a/json_serialization/reader.nim
+++ b/json_serialization/reader.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))

--- a/json_serialization/reader_desc.nim
+++ b/json_serialization/reader_desc.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -8,6 +8,7 @@
 # those terms.
 
 {.experimental: "notnil".}
+{.push raises: [], gcsafe.}
 
 import
   std/[strformat],
@@ -64,8 +65,6 @@ type
 
 Json.setReader JsonReader
 
-{.push gcsafe, raises: [].}
-
 func valueStr(err: ref IntOverflowError): string =
   if err.isNegative:
     result.add '-'
@@ -75,32 +74,25 @@ template tryFmt(expr: untyped): string =
   try: expr
   except CatchableError as err: err.msg
 
-method formatMsg*(err: ref JsonReaderError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref JsonReaderError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) Error while reading json file: {err.msg}"
 
-method formatMsg*(err: ref UnexpectedField, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref UnexpectedField, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) Unexpected field '{err.encounteredField}' while deserializing {err.deserializedType}"
 
-method formatMsg*(err: ref UnexpectedTokenError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref UnexpectedTokenError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) Unexpected token '{err.encountedToken}' in place of '{err.expectedToken}'"
 
-method formatMsg*(err: ref GenericJsonReaderError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref GenericJsonReaderError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) Exception encountered while deserializing '{err.deserializedField}': [{err.innerException.name}] {err.innerException.msg}"
 
-method formatMsg*(err: ref IntOverflowError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref IntOverflowError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) The value '{err.valueStr}' is outside of the allowed range"
 
-method formatMsg*(err: ref UnexpectedValueError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref UnexpectedValueError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) {err.msg}"
 
-method formatMsg*(err: ref IncompleteObjectError, filename: string):
-    string {.gcsafe, raises: [].} =
+method formatMsg*(err: ref IncompleteObjectError, filename: string): string =
   tryFmt: fmt"{filename}({err.line}, {err.col}) Not all required fields were specified when reading '{err.objectType}'"
 
 func assignLineNumber*(ex: ref JsonReaderError, lex: JsonLexer) =
@@ -184,13 +176,13 @@ template handleReadException*(r: JsonReader,
 proc init*(T: type JsonReader,
            stream: InputStream,
            flags: JsonReaderFlags,
-           conf: JsonReaderConf = defaultJsonReaderConf): T {.raises: [].} =
+           conf: JsonReaderConf = defaultJsonReaderConf): T =
   result.lex = JsonLexer.init(stream, flags, conf)
 
 proc init*(T: type JsonReader,
            stream: InputStream,
            allowUnknownFields = false,
-           requireAllFields = false): T {.raises: [].} =
+           requireAllFields = false): T =
   mixin flavorAllowsUnknownFields, flavorRequiresAllFields
   type Flavor = T.Flavor
 

--- a/json_serialization/std/net.nim
+++ b/json_serialization/std/net.nim
@@ -1,11 +1,13 @@
 # json-serialization
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [], gcsafe.}
 
 import
   std/[net, strutils],

--- a/json_serialization/std/options.nim
+++ b/json_serialization/std/options.nim
@@ -1,11 +1,13 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [], gcsafe.}
 
 import std/options, ../../json_serialization/[reader, writer, lexer]
 export options
@@ -21,7 +23,8 @@ proc writeValue*(writer: var JsonWriter, value: Option) {.raises: [IOError].} =
   else:
     writer.writeValue JsonString("null")
 
-proc readValue*[T](reader: var JsonReader, value: var Option[T]) =
+proc readValue*[T](reader: var JsonReader, value: var Option[T]) {.
+      raises: [IOError, SerializationError].} =
   mixin readValue
 
   if reader.tokKind == JsonValueKind.Null:

--- a/json_serialization/std/sets.nim
+++ b/json_serialization/std/sets.nim
@@ -1,11 +1,13 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [], gcsafe.}
 
 import stew/shims/sets, ../../json_serialization/[reader, writer, lexer]
 export sets
@@ -16,7 +18,8 @@ type
 proc writeValue*(writer: var JsonWriter, value: SetType) {.raises: [IOError].} =
   writer.writeIterable value
 
-proc readValue*(reader: var JsonReader, value: var SetType) =
+proc readValue*(reader: var JsonReader, value: var SetType) {.
+      raises: [IOError, SerializationError].} =
   type ElemType = type(value.items)
   value = init SetType
   for elem in readArray(reader, ElemType):

--- a/json_serialization/std/tables.nim
+++ b/json_serialization/std/tables.nim
@@ -1,11 +1,13 @@
 # json-serialization
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [], gcsafe.}
 
 import
   std/strutils,
@@ -36,7 +38,8 @@ template to*(a: string, b: type float): float =
 template to*(a: string, b: type string): string =
   a
 
-proc readValue*(reader: var JsonReader, value: var TableType) =
+proc readValue*(reader: var JsonReader, value: var TableType) {.
+      raises: [IOError, SerializationError].} =
   try:
     type KeyType = type(value.keys)
     type ValueType = type(value.values)

--- a/json_serialization/types.nim
+++ b/json_serialization/types.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push gcsafe, raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/tables,

--- a/json_serialization/value_ops.nim
+++ b/json_serialization/value_ops.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,11 +7,11 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/[tables, strutils],
   ./types
-
-{.push gcsafe, raises: [].}
 
 proc len*(n: JsonValueRef): int =
   ## If `n` is a `JsonValueKind.Array`, it returns the number of elements.

--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -22,7 +22,8 @@
 ## Finally, `streamElement` can be used when direct access to the stream is
 ## needed, for example to efficiently encode a value without intermediate
 ## allocations.
-{.push gcsafe, raises: [].}
+
+{.push raises: [], gcsafe.}
 
 import
   std/[json, typetraits],
@@ -524,7 +525,7 @@ template configureJsonSerialization*(
     T: type[enum], enumRep: static[EnumRepresentation]) =
   ## Configure JSON serialization for an enum type with a specific representation.
   proc writeValue*(w: var JsonWriter,
-                   value: T) {.gcsafe, raises: [IOError].} =
+                   value: T) {.raises: [IOError].} =
     writeEnumImpl(w, value, enumRep)
 
 template configureJsonSerialization*(Flavor: type,
@@ -533,9 +534,9 @@ template configureJsonSerialization*(Flavor: type,
   ## Configure JSON serialization for an enum type and flavor with a specific representation.
   when Flavor is Json:
     proc writeValue*(w: var JsonWriter[DefaultFlavor],
-                     value: T) {.gcsafe, raises: [IOError].} =
+                     value: T) {.raises: [IOError].} =
       writeEnumImpl(w, value, enumRep)
   else:
     proc writeValue*(w: var JsonWriter[Flavor],
-                     value: T) {.gcsafe, raises: [IOError].} =
+                     value: T) {.raises: [IOError].} =
       writeEnumImpl(w, value, enumRep)

--- a/tests/test_reader.nim
+++ b/tests/test_reader.nim
@@ -18,11 +18,11 @@ createJsonFlavor NullFields,
   skipNullFields = true
 
 func toReader(input: string): JsonReader[DefaultFlavor] =
-  var stream = unsafeMemoryInput(input)
+  var stream = memoryInput(input)
   JsonReader[DefaultFlavor].init(stream)
 
 func toReaderNullFields(input: string): JsonReader[NullFields] =
-  var stream = unsafeMemoryInput(input)
+  var stream = memoryInput(input)
   JsonReader[NullFields].init(stream)
 
 const
@@ -220,3 +220,20 @@ suite "JsonReader basic test":
     var r = toReader "[false, true, false]"
     expect JsonReaderError:
       discard r.readValue(array[2, bool])
+
+  test "readValue of object without fields":
+    type NoFields = object
+
+    block:
+      var stream = memoryInput(jsonText)
+      var r = JsonReader[DefaultFlavor].init(stream, allowUnknownFields=true)
+
+      check:
+        r.readValue(NoFields) == NoFields()
+
+    block:
+      var stream = memoryInput(jsonText)
+      var r = JsonReader[DefaultFlavor].init(stream, allowUnknownFields=false)
+
+      expect(JsonReaderError):
+        discard r.readValue(NoFields)

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -293,3 +293,8 @@ suite "Test writer":
 
   test "escapes":
     check Json.encode("\x12") == """"\u0012""""
+
+  test "Empty object":
+    type NoFields = object
+
+    check: Json.encode(default(NoFields)) == "{}"


### PR DESCRIPTION
When an object has no fields, it must still consume the contents, either skipping or raising

Bonus:
* fewer enumAllSerializedFields for a tiny compilation speed improvement
* make raises more uniform