### PR TITLE
chore: fix serialization of distinct integer types (uint16, …) on Windows

### DIFF
--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -431,7 +431,10 @@ template writeValueObjectOrTuple(Flavor, w, value) =
     {.error: "Please override writeValue for the " & typeName & " type (or import the module where the override is provided)".}
 
   when value is distinct:
-    writeRecordValue(w, distinctBase(value, recursive = false))
+    when distinctBase(value) is object|tuple:
+      writeRecordValue(w, distinctBase(value, recursive = false))
+    else:
+      writeValue(w, distinctBase(value, recursive = false))
   else:
     writeRecordValue(w, value)
 


### PR DESCRIPTION
`writeValueObjectOrTuple` sends every `distinct` type straight to `writeRecordValue`.  
On Windows the fundamental integers (`uint16`, `uint32`, …) are declared as `distinct uint`, i.e. wrappers around a primitive—not an object or tuple—so the resulting call signature doesn’t match and the compiler errors out.

```
type
  WrappedPoint = distinct tuple[x:int, y:int]   # still a tuple inside
  WrappedU16    = distinct uint16               # primitive inside

var w = JsonWriter.init(memoryOutput())

let p: WrappedPoint = (x: 3, y: 4)
let n: WrappedU16   = 42

w.writeValue(p)   # → {"x":3,"y":4}  uses record path
w.writeValue(n)   # → 42             uses integer path```