### PR TITLE
Fix missing escaping of backslashes in writing string value

### DIFF
--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -459,6 +459,7 @@ template writeValueStringLike(w, value) =
       of '\f': addPrefixSlash 'f' # \x0c
       of '\r': addPrefixSlash 'r' # \x0d
       of '"' : addPrefixSlash '\"'
+      of '\\': addPrefixSlash '\\'
       of '\x00'..'\x07', '\x0b', '\x0e'..'\x1f':
         s.write "\\u00"
         s.write hexChars[(uint8(c) shr 4) and 0x0f]

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -24,9 +24,11 @@ type
     b: Option[string]
     c: int
 
-createJsonFlavor YourJson, omitOptionalFields = false
+createJsonFlavor YourJson,
+  omitOptionalFields = false
 
-createJsonFlavor MyJson, omitOptionalFields = true
+createJsonFlavor MyJson,
+  omitOptionalFields = true
 
 ObjectWithOptionalFields.useDefaultSerializationIn YourJson
 ObjectWithOptionalFields.useDefaultSerializationIn MyJson
@@ -34,8 +36,8 @@ ObjectWithOptionalFields.useDefaultSerializationIn MyJson
 type
   FruitX = enum
     BananaX = "BaNaNa"
-    AppleX = "ApplE"
-    GrapeX = "VVV"
+    AppleX  = "ApplE"
+    GrapeX  = "VVV"
 
   Drawer = enum
     One
@@ -45,7 +47,8 @@ FruitX.configureJsonSerialization(EnumAsString)
 Json.configureJsonSerialization(Drawer, EnumAsNumber)
 MyJson.configureJsonSerialization(Drawer, EnumAsString)
 
-proc writeValue*(w: var JsonWriter, val: OWOF) {.gcsafe, raises: [IOError].} =
+proc writeValue*(w: var JsonWriter, val: OWOF)
+                  {.gcsafe, raises: [IOError].} =
   w.writeObject(OWOF):
     w.writeField("a", val.a)
     w.writeField("b", val.b)
@@ -137,9 +140,17 @@ suite "Test writer":
     check json == "[123,null,777]"
 
   test "object with optional fields":
-    let x = ObjectWithOptionalFields(a: Opt.some(123), b: some("nano"), c: 456)
+    let x = ObjectWithOptionalFields(
+      a: Opt.some(123),
+      b: some("nano"),
+      c: 456,
+    )
 
-    let y = ObjectWithOptionalFields(a: Opt.none(int), b: none(string), c: 999)
+    let y = ObjectWithOptionalFields(
+      a: Opt.none(int),
+      b: none(string),
+      c: 999,
+    )
 
     let u = YourJson.encode(x)
     check u == """{"a":123,"b":"nano","c":456}"""
@@ -154,9 +165,17 @@ suite "Test writer":
     check yy == """{"c":999}"""
 
   test "writeField with object with optional fields":
-    let x = OWOF(a: Opt.some(123), b: some("nano"), c: 456)
+    let x = OWOF(
+      a: Opt.some(123),
+      b: some("nano"),
+      c: 456,
+    )
 
-    let y = OWOF(a: Opt.none(int), b: none(string), c: 999)
+    let y = OWOF(
+      a: Opt.none(int),
+      b: none(string),
+      c: 999,
+    )
 
     let xx = MyJson.encode(x)
     check xx == """{"a":123,"b":"nano","c":456}"""
@@ -193,10 +212,11 @@ suite "Test writer":
       check true
 
   test "Enum value representation of DefaultFlavor":
-    type ExoticFruits = enum
-      DragonFruit
-      SnakeFruit
-      StarFruit
+    type
+      ExoticFruits = enum
+        DragonFruit
+        SnakeFruit
+        StarFruit
 
     DefaultFlavor.flavorEnumRep(EnumAsNumber)
     let u = Json.encode(DragonFruit)
@@ -214,7 +234,7 @@ suite "Test writer":
     type
       Fruit = enum
         Banana = "BaNaNa"
-        Apple = "ApplE"
+        Apple  = "ApplE"
         JackFruit = "VVV"
 
       ObjectWithEnumField = object
@@ -278,5 +298,4 @@ suite "Test writer":
   test "Empty object":
     type NoFields = object
 
-    check:
-      Json.encode(default(NoFields)) == "{}"
+    check: Json.encode(default(NoFields)) == "{}"

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -24,11 +24,9 @@ type
     b: Option[string]
     c: int
 
-createJsonFlavor YourJson,
-  omitOptionalFields = false
+createJsonFlavor YourJson, omitOptionalFields = false
 
-createJsonFlavor MyJson,
-  omitOptionalFields = true
+createJsonFlavor MyJson, omitOptionalFields = true
 
 ObjectWithOptionalFields.useDefaultSerializationIn YourJson
 ObjectWithOptionalFields.useDefaultSerializationIn MyJson
@@ -36,8 +34,8 @@ ObjectWithOptionalFields.useDefaultSerializationIn MyJson
 type
   FruitX = enum
     BananaX = "BaNaNa"
-    AppleX  = "ApplE"
-    GrapeX  = "VVV"
+    AppleX = "ApplE"
+    GrapeX = "VVV"
 
   Drawer = enum
     One
@@ -47,8 +45,7 @@ FruitX.configureJsonSerialization(EnumAsString)
 Json.configureJsonSerialization(Drawer, EnumAsNumber)
 MyJson.configureJsonSerialization(Drawer, EnumAsString)
 
-proc writeValue*(w: var JsonWriter, val: OWOF)
-                  {.gcsafe, raises: [IOError].} =
+proc writeValue*(w: var JsonWriter, val: OWOF) {.gcsafe, raises: [IOError].} =
   w.writeObject(OWOF):
     w.writeField("a", val.a)
     w.writeField("b", val.b)
@@ -140,17 +137,9 @@ suite "Test writer":
     check json == "[123,null,777]"
 
   test "object with optional fields":
-    let x = ObjectWithOptionalFields(
-      a: Opt.some(123),
-      b: some("nano"),
-      c: 456,
-    )
+    let x = ObjectWithOptionalFields(a: Opt.some(123), b: some("nano"), c: 456)
 
-    let y = ObjectWithOptionalFields(
-      a: Opt.none(int),
-      b: none(string),
-      c: 999,
-    )
+    let y = ObjectWithOptionalFields(a: Opt.none(int), b: none(string), c: 999)
 
     let u = YourJson.encode(x)
     check u == """{"a":123,"b":"nano","c":456}"""
@@ -165,17 +154,9 @@ suite "Test writer":
     check yy == """{"c":999}"""
 
   test "writeField with object with optional fields":
-    let x = OWOF(
-      a: Opt.some(123),
-      b: some("nano"),
-      c: 456,
-    )
+    let x = OWOF(a: Opt.some(123), b: some("nano"), c: 456)
 
-    let y = OWOF(
-      a: Opt.none(int),
-      b: none(string),
-      c: 999,
-    )
+    let y = OWOF(a: Opt.none(int), b: none(string), c: 999)
 
     let xx = MyJson.encode(x)
     check xx == """{"a":123,"b":"nano","c":456}"""
@@ -212,11 +193,10 @@ suite "Test writer":
       check true
 
   test "Enum value representation of DefaultFlavor":
-    type
-      ExoticFruits = enum
-        DragonFruit
-        SnakeFruit
-        StarFruit
+    type ExoticFruits = enum
+      DragonFruit
+      SnakeFruit
+      StarFruit
 
     DefaultFlavor.flavorEnumRep(EnumAsNumber)
     let u = Json.encode(DragonFruit)
@@ -234,7 +214,7 @@ suite "Test writer":
     type
       Fruit = enum
         Banana = "BaNaNa"
-        Apple  = "ApplE"
+        Apple = "ApplE"
         JackFruit = "VVV"
 
       ObjectWithEnumField = object
@@ -293,8 +273,10 @@ suite "Test writer":
 
   test "escapes":
     check Json.encode("\x12") == """"\u0012""""
+    check Json.encode("""a\b""") == """"a\\b""""
 
   test "Empty object":
     type NoFields = object
 
-    check: Json.encode(default(NoFields)) == "{}"
+    check:
+      Json.encode(default(NoFields)) == "{}"


### PR DESCRIPTION
nwaku - js-waku interop tests failed and revealed that JSON serialization misses escaping `\` backslash characters - escaping the escape character was missing in the writer for strings.

Fixes: https://github.com/waku-org/nwaku/issues/3572
