### PR TITLE
Avoid write float alloc

### DIFF
--- a/json_serialization/writer.nim
+++ b/json_serialization/writer.nim
@@ -527,9 +527,7 @@ proc writeValue*[V: not void](w: var JsonWriter, value: V) {.raises: [IOError].}
   elif value is SomeFloat:
     autoSerializeCheck(Flavor, SomeFloat, typeof(value)):
       w.streamElement(s):
-        # TODO Implement writeText for floats
-        #      to avoid the allocation here:
-        s.write $value
+        s.writeText value
 
   elif value is seq or(value is distinct and distinctBase(value) is seq):
     autoSerializeCheck(Flavor, seq, typeof(value)):

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -376,6 +376,11 @@ suite "toJson tests":
       "".toJson == "\"\""
       "abc".toJson == "\"abc\""
 
+  test "float":
+    Json.roundtripTest 1.23, "1.23"
+    Json.roundtripTest 1.23'f32, "1.23"
+    Json.roundtripTest 1.23'f64, "1.23"
+
   test "enums":
     Json.roundtripTest x0, "\"x0\""
     Json.roundtripTest x1, "\"x1\""


### PR DESCRIPTION
- Avoid write float alloc
- Allows float roundtrip
- Output is consistent at runtime, comptime and across Nim versions

This was added in faststreams 0.5.0 (https://github.com/status-im/nim-faststreams/pull/82) which is already the min required version in .nimble.