### PR TITLE
CI: use nimble 0.20.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
+      nimble-version: b920dad9ed76c6619be3ec0cfbf0dde6f9e39092
       test-command: |
         env NIMLANG=c nimble test
         env NIMLANG=cpp nimble test


### PR DESCRIPTION
nim-ser dropped support for Nim 1.6 https://github.com/status-im/nim-serialization/pull/109.
we need Nimble 0.20.1 in CI to resolve the dependency conflict
alternatively, drop support for nim 1.6 too