### PR TITLE
Run tests at comptime

### DIFF
--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -21,7 +21,7 @@ requires "nim >= 1.6.0",
          "serialization",
          "stew >= 0.2.0",
          "results",
-         "https://github.com/nitely/nim-serialization#0e90655d3f851529cc70e05f1e0b038656eafdf1"
+         "https://github.com/nitely/nim-serialization#6011d2662cbcb9cf84f6376e6a46b6f6728a22d2"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -36,7 +36,8 @@ let cfg =
   (if verbose: "" else: " --verbosity:0 --hints:off") &
   " --outdir:build " &
   quoteShell("--nimcache:build/nimcache/$projectName") &
-  " -d:nimOldCaseObjects -d:unittest2Static -d:serializationTestAllRountrips"
+  " -d:nimOldCaseObjects -d:serializationTestAllRountrips" &
+  (if NimMajor >= 2: " -d:unittest2Static" else: "")
 
 proc build(args, path: string) =
   exec nimc & " " & lang & " " & cfg & " " & flags & " " & args & " " & path

--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -20,8 +20,7 @@ requires "nim >= 1.6.0",
          "faststreams >= 0.5.0",
          "serialization",
          "stew >= 0.2.0",
-         "results",
-         "https://github.com/nitely/nim-serialization#6011d2662cbcb9cf84f6376e6a46b6f6728a22d2"
+         "results"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -21,7 +21,7 @@ requires "nim >= 1.6.0",
          "serialization",
          "stew >= 0.2.0",
          "results",
-         "https://github.com/status-im/nim-serialization#0e90655d3f851529cc70e05f1e0b038656eafdf1"
+         "https://github.com/nitely/nim-serialization#0e90655d3f851529cc70e05f1e0b038656eafdf1"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -20,7 +20,8 @@ requires "nim >= 1.6.0",
          "faststreams >= 0.5.0",
          "serialization",
          "stew >= 0.2.0",
-         "results"
+         "results",
+         "https://github.com/status-im/nim-serialization#0e90655d3f851529cc70e05f1e0b038656eafdf1"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
@@ -35,7 +36,7 @@ let cfg =
   (if verbose: "" else: " --verbosity:0 --hints:off") &
   " --outdir:build " &
   quoteShell("--nimcache:build/nimcache/$projectName") &
-  " -d:nimOldCaseObjects"
+  " -d:nimOldCaseObjects -d:unittest2Static -d:serializationTestAllRountrips"
 
 proc build(args, path: string) =
   exec nimc & " " & lang & " " & cfg & " " & flags & " " & args & " " & path

--- a/tests/test_json_flavor.nim
+++ b/tests/test_json_flavor.nim
@@ -142,6 +142,7 @@ suite "Test JsonFlavor":
     check y.list.string.len == 0
 
   test "Enum value representation primitives":
+    NullyFields.flavorEnumRep(EnumAsString)
     when NullyFields.flavorEnumRep() == EnumAsString:
       check true
     elif NullyFields.flavorEnumRep() == EnumAsNumber:

--- a/tests/test_line_col.nim
+++ b/tests/test_line_col.nim
@@ -122,7 +122,7 @@ const testCases = [
 
 suite "Test line col":
   for i, tc in testCases:
-    test $i:
+    runtimeTest $i:
       var stream = unsafeMemoryInput(tc.text)
       var lex = init(JsonLexer, stream, tc.flags, tc.conf)
       var value: JsonValueRef[uint64]

--- a/tests/test_reader.nim
+++ b/tests/test_reader.nim
@@ -146,6 +146,8 @@ suite "JsonReader basic test":
       r.readValue(valOrig)
       # workaround for https://github.com/nim-lang/Nim/issues/24274
       let val = valOrig
+      # TODO: https://github.com/status-im/nim-unittest2/pull/58
+      doAssert val.seven[] == 555
       check:
         val.one == JsonString("[1,true,null]")
         val.two.num == 123
@@ -153,7 +155,7 @@ suite "JsonReader basic test":
         val.four ==  "012"
         val.five ==  "345"
         val.six ==  true
-        val.seven[] == 555
+        #val.seven[] == 555
         val.eight ==  mTwo
         val.nine ==  77
         val.ten ==  88

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -236,7 +236,7 @@ proc readValue*(r: var JsonReader[DefaultFlavor], value: var MyCaseObject)
 {.pop.}
 
 var
-  customVisit: TokenRegistry
+  customVisit {.global, compileTime.}: TokenRegistry
 
 Json.useCustomSerialization(WithCustomFieldRule.intVal):
   read:
@@ -377,14 +377,14 @@ suite "toJson tests":
       "abc".toJson == "\"abc\""
 
   test "float":
-    Json.roundtripTest 1.23, "1.23"
-    Json.roundtripTest 1.23'f32, "1.23"
-    Json.roundtripTest 1.23'f64, "1.23"
+    Json.roundtripChecks 1.23, "1.23"
+    Json.roundtripChecks 1.23'f32, "1.23"
+    Json.roundtripChecks 1.23'f64, "1.23"
 
   test "enums":
-    Json.roundtripTest x0, "\"x0\""
-    Json.roundtripTest x1, "\"x1\""
-    Json.roundtripTest x2, "\"x2\""
+    Json.roundtripChecks x0, "\"x0\""
+    Json.roundtripChecks x1, "\"x1\""
+    Json.roundtripChecks x2, "\"x2\""
     expect UnexpectedTokenError:
       discard Json.decode("0", EnumTestX)
     expect UnexpectedTokenError:
@@ -406,10 +406,10 @@ suite "toJson tests":
     expect UnexpectedValueError:
       discard Json.decode("\"0\"", EnumTestX)
 
-    Json.roundtripTest y1, "\"y1\""
-    Json.roundtripTest y3, "\"y3\""
-    Json.roundtripTest y4, "\"y4\""
-    Json.roundtripTest y6, "\"y6\""
+    Json.roundtripChecks y1, "\"y1\""
+    Json.roundtripChecks y3, "\"y3\""
+    Json.roundtripChecks y4, "\"y4\""
+    Json.roundtripChecks y6, "\"y6\""
     check:
       Json.decode("1", EnumTestY) == y1
       Json.decode("3", EnumTestY) == y3
@@ -438,9 +438,9 @@ suite "toJson tests":
     expect UnexpectedValueError:
       discard Json.decode("\"1\"", EnumTestY)
 
-    Json.roundtripTest z1, "\"aaa\""
-    Json.roundtripTest z2, "\"bbb\""
-    Json.roundtripTest z3, "\"ccc\""
+    Json.roundtripChecks z1, "\"aaa\""
+    Json.roundtripChecks z2, "\"bbb\""
+    Json.roundtripChecks z3, "\"ccc\""
     expect UnexpectedTokenError:
       discard Json.decode("0", EnumTestZ)
     expect UnexpectedValueError:
@@ -458,9 +458,9 @@ suite "toJson tests":
     expect UnexpectedValueError:
       discard Json.decode("\"\ud83d\udc3c\"", EnumTestZ)
 
-    Json.roundtripTest n1, "\"aaa\""
-    Json.roundtripTest n2, "\"bbb\""
-    Json.roundtripTest n3, "\"ccc\""
+    Json.roundtripChecks n1, "\"aaa\""
+    Json.roundtripChecks n2, "\"bbb\""
+    Json.roundtripChecks n3, "\"ccc\""
     check:
       Json.decode("\"aAA\"", EnumTestN) == n1
       Json.decode("\"bBB\"", EnumTestN) == n2
@@ -491,9 +491,9 @@ suite "toJson tests":
     expect UnexpectedValueError:
       discard Json.decode("\"\ud83d\udc3c\"", EnumTestN)
 
-    Json.roundtripTest o1, "\"o1\""
-    Json.roundtripTest o2, "\"o2\""
-    Json.roundtripTest o3, "\"o3\""
+    Json.roundtripChecks o1, "\"o1\""
+    Json.roundtripChecks o2, "\"o2\""
+    Json.roundtripChecks o3, "\"o3\""
     check:
       Json.decode("\"o_1\"", EnumTestO) == o1
       Json.decode("\"o_2\"", EnumTestO) == o2
@@ -656,7 +656,10 @@ suite "toJson tests":
     let decoded = try:
       Json.decode(json, Simple, requireAllFields = true, allowUnknownFields = true)
     except SerializationError as err:
-      checkpoint "Unexpected deserialization failure: " & err.formatMsg("<input>")
+      when nimvm:
+        checkpoint "Unexpected deserialization failure: " & err.msg
+      else:
+        checkpoint "Unexpected deserialization failure: " & err.formatMsg("<input>")
       raise
 
     check:
@@ -737,8 +740,8 @@ suite "toJson tests":
       h3 = Json.decode("""{"r":{"distance":3,"x":1,"y":"2"}}""",
                        HoldsOption, requireAllFields = true)
 
-    Json.roundtripTest h1, """{"r":null,"o":{"distance":3,"x":1,"y":"2"}}"""
-    Json.roundtripTest h2, """{"r":{"distance":3,"x":1,"y":"2"}}"""
+    Json.roundtripChecks h1, """{"r":null,"o":{"distance":3,"x":1,"y":"2"}}"""
+    Json.roundtripChecks h2, """{"r":{"distance":3,"x":1,"y":"2"}}"""
 
     check h3 == h2
 
@@ -754,10 +757,10 @@ suite "toJson tests":
       h5 = OtherOptionTest(b: some Meter(2))
       h6 = OtherOptionTest(a: some Meter(3), b: some Meter(4))
 
-    Json.roundtripTest h3, """{}"""
-    Json.roundtripTest h4, """{"a":1}"""
-    Json.roundtripTest h5, """{"b":2}"""
-    Json.roundtripTest h6, """{"a":3,"b":4}"""
+    Json.roundtripChecks h3, """{}"""
+    Json.roundtripChecks h4, """{"a":1}"""
+    Json.roundtripChecks h5, """{"b":2}"""
+    Json.roundtripChecks h6, """{"a":3,"b":4}"""
 
     let
       arr = @[some h3, some h4, some h5, some h6, none(OtherOptionTest)]
@@ -796,11 +799,11 @@ suite "toJson tests":
         # lent iterator error
         let a = a
         let b = b
-        Json.roundtripTest NestedOptionTest(c: a, d: b), results[r]
+        Json.roundtripChecks NestedOptionTest(c: a, d: b), results[r]
         r.inc
 
-    Json.roundtripTest SeqOptionTest(a: @[some 5.Meter, none Meter], b: Meter(5)), """{"a":[5,null],"b":5}"""
-    Json.roundtripTest OtherOptionTest2(a: some 5.Meter, b: none Meter, c: some 10.Meter), """{"a":5,"c":10}"""
+    Json.roundtripChecks SeqOptionTest(a: @[some 5.Meter, none Meter], b: Meter(5)), """{"a":[5,null],"b":5}"""
+    Json.roundtripChecks OtherOptionTest2(a: some 5.Meter, b: none Meter, c: some 10.Meter), """{"a":5,"c":10}"""
 
   test "Result Opt types":
     check:
@@ -812,8 +815,8 @@ suite "toJson tests":
       h1 = HoldsResultOpt(o: Opt[Simple].ok Simple(x: 1, y: "2", distance: Meter(3)))
       h2 = HoldsResultOpt(r: newSimple(1, "2", Meter(3)))
 
-    Json.roundtripTest h1, """{"o":{"distance":3,"x":1,"y":"2"},"r":null}"""
-    Json.roundtripTest h2, """{"r":{"distance":3,"x":1,"y":"2"}}"""
+    Json.roundtripChecks h1, """{"o":{"distance":3,"x":1,"y":"2"},"r":null}"""
+    Json.roundtripChecks h2, """{"r":{"distance":3,"x":1,"y":"2"}}"""
 
     let
       h3 = Json.decode("""{"r":{"distance":3,"x":1,"y":"2"}}""",
@@ -828,7 +831,7 @@ suite "toJson tests":
 
   test "Custom field serialization":
     let obj = WithCustomFieldRule(str: "test", intVal: 10)
-    Json.roundtripTest obj, """{"str":"test","intVal":"10"}"""
+    Json.roundtripChecks obj, """{"str":"test","intVal":"10"}"""
 
   test "Case object as field":
     let
@@ -911,7 +914,10 @@ suite "toJson tests":
 
     except SerializationError as e:
       echo e.getStackTrace
-      echo e.formatMsg("<>")
+      when nimvm:
+        echo e.msg
+      else:
+        echo e.formatMsg("<>")
       raise e
 
   test "Holders of JsonString":
@@ -927,7 +933,10 @@ suite "toJson tests":
       let decoded = Json.decode(jsonContent, JsonNode)
       check decoded["tasks"][0]["label"] == newJString("nimbus-eth2 build")
     except SerializationError as err:
-      checkpoint err.formatMsg("./cases/comments.json")
+      when nimvm:
+        checkpoint "<./cases/comments.json> " & err.msg
+      else:
+        checkpoint err.formatMsg("./cases/comments.json")
       check false
 
   test "A nil cstring":

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -188,6 +188,7 @@ suite "Test writer":
     check vv == """{"a":null,"b":null,"c":999}"""
 
   test "Enum value representation primitives":
+    DefaultFlavor.flavorEnumRep(EnumAsString)
     when DefaultFlavor.flavorEnumRep() == EnumAsString:
       check true
     elif DefaultFlavor.flavorEnumRep() == EnumAsNumber:


### PR DESCRIPTION
Run all tests at comptime.

In Nim 1.6.x only the spec tests are ran at comptime, because nim-serialization resolves to an older version that does not support running its generic test suite at comptime.