### PR TITLE
Use cargo binstall in doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,31 +10,33 @@ jobs:
   build:
     timeout-minutes: 20
 
-    name: 'Generate & upload documentation'
-    runs-on: 'ubuntu-latest'
+    name: "Generate & upload documentation"
+    runs-on: "ubuntu-latest"
     continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/*.nimble') }}
+
+      - name: Setup cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install mdBook and preprocessors
+        run: |
+          cargo binstall mdbook@0.4.51 \
+            mdbook-toc@0.14.2 \
+            mdbook-open-on-gh@2.4.3 \
+            mdbook-admonish@1.20.0
+
       - uses: jiro4989/setup-nim-action@v1
         with:
-          nim-version: '2.2.4'
+          nim-version: "2.2.4"
 
       - name: Generate doc
         run: |
           nim --version
           nimble --version
-          nimble mdbook
           nimble docs || true
 
       - name: Deploy

--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -56,9 +56,6 @@ task examples, "Build examples":
     if file.endsWith(".nim"):
       build "--threads:on", file
 
-task mdbook, "Install mdbook (requires cargo)":
-  exec "cargo install mdbook@0.4.51 mdbook-toc@0.14.2 mdbook-open-on-gh@2.4.3 mdbook-admonish@1.20.0"
-
 task docs, "Generate API documentation":
   exec "mdbook build docs"
   exec nimc & " doc " & "--git.url:https://github.com/status-im/nim-json-serialization --git.commit:master --outdir:docs/book/api --project json_serialization"


### PR DESCRIPTION
A similar change in https://github.com/status-im/nim-chronos/pull/612 resulted in dramatic doc build time improvement: 8 mins → 38 secs. We can expect similar improvement here.