### PR TITLE
CI: remove pinned nimble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
       test-command: |
+        nimble list --installed --version
         env NIMLANG=c nimble --useSystemNim test
         env NIMLANG=cpp nimble --useSystemNim test
         env nimble --useSystemNim examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       test-command: |
         nimble list --installed --version
-        env NIMLANG=c nimble --useSystemNim test
-        env NIMLANG=cpp nimble --useSystemNim test
-        env nimble --useSystemNim examples
+        env NIMLANG=c nimble test
+        env NIMLANG=cpp nimble test
+        env nimble examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
-      nimble-version: b920dad9ed76c6619be3ec0cfbf0dde6f9e39092
       test-command: |
-        env NIMLANG=c nimble test
-        env NIMLANG=cpp nimble test
-
-        env nimble examples
+        env NIMLANG=c nimble --useSystemNim test
+        env NIMLANG=cpp nimble --useSystemNim test
+        env nimble --useSystemNim examples


### PR DESCRIPTION
Changes:

- Remove pinned version; [currently will use Nimble 0.22.3](https://github.com/status-im/nimbus-common-workflow/blob/6dd41badc11672ee11244cfb8e493522e9d7970d/.github/workflows/common.yml#L18)