### PR TITLE
optimize bulk JSON decoding

### DIFF
--- a/json_serialization.nimble
+++ b/json_serialization.nimble
@@ -19,7 +19,7 @@ skipDirs      = @["tests", "fuzzer"]
 requires "nim >= 1.6.0",
          "faststreams >= 0.5.0",
          "serialization",
-         "stew >= 0.2.0",
+         "stew >= 0.5.1",
          "results"
 
 from std/os import quoteShell

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -538,8 +538,6 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
               base[i] >= 0x20'u8:
           inc i
         if i > 0:
-          # Honor the string-length limit exactly as the per-char path does:
-          # copy the portion of the run that fits, then raise.
           var take = i
           let hitLimit = limit > 0 and strLen + take > limit
           if hitLimit:
@@ -547,7 +545,13 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
           if take > 0:
             when T is string:
               let old = val.len
-              val.setLen(old + take)
+              # https://github.com/nim-lang/Nim/pull/24836
+              # https://github.com/nim-lang/Nim/pull/25767
+              when (NimMajor, NimMinor, NimPatch) < (2, 2, 10) or
+                   ((NimMajor, NimMinor) < (2, 4) and defined(gcRefc)):
+                val.setLen(old + take)
+              else:
+                val.setLenUninit(old + take)
               copyMem(addr val[old], base, take)
             inc strLen, take
             lex.stream.span.advance(take)

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -15,6 +15,7 @@ import
   types
 
 from stew/ptrops import makeUncheckedArray
+from stew/shims/struninit import setLenUninit2
 from faststreams/buffers import len, advance
 
 export
@@ -545,13 +546,7 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
           if take > 0:
             when T is string:
               let old = val.len
-              # https://github.com/nim-lang/Nim/pull/24836
-              # https://github.com/nim-lang/Nim/pull/25767
-              when (NimMajor, NimMinor, NimPatch) < (2, 2, 10) or
-                   ((NimMajor, NimMinor) < (2, 4) and defined(gcRefc)):
-                val.setLen(old + take)
-              else:
-                val.setLenUninit(old + take)
+              val.setLenUninit2(old + take)
               copyMem(addr val[old], base, take)
             inc strLen, take
             lex.stream.span.advance(take)

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -547,7 +547,7 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
           if take > 0:
             when T is string:
               let old = val.len
-              val.setLen(old + take)
+              val.setLenUninit(old + take)
               copyMem(addr val[old], base, take)
             inc strLen, take
             lex.stream.span.advance(take)

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -547,7 +547,7 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
           if take > 0:
             when T is string:
               let old = val.len
-              val.setLenUninit(old + take)
+              val.setLen(old + take)
               copyMem(addr val[old], base, take)
             inc strLen, take
             lex.stream.span.advance(take)

--- a/json_serialization/lexer.nim
+++ b/json_serialization/lexer.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -13,6 +13,9 @@ import
   std/[json, unicode],
   faststreams/inputs,
   types
+
+from stew/ptrops import makeUncheckedArray
+from faststreams/buffers import len, advance
 
 export
   inputs, types
@@ -124,14 +127,14 @@ template enterNestedStructure(lex: JsonLexer, action: untyped) {.dirty.} =
 template exitNestedStructure(lex: JsonLexer) =
   dec lex.depthLimit
 
-proc handleLF(lex: var JsonLexer) =
+func handleLF(lex: var JsonLexer) =
   lex.advance
   lex.line += 1
   lex.lineStartPos = lex.stream.pos
   lex.tokenStart = lex.stream.pos
 
-proc isDigit(c: char): bool =
-  return (c >= '0' and c <= '9')
+func isDigit(c: char): bool =
+  c >= '0' and c <= '9'
 
 template eatDigitAndPeek(body: untyped): char =
   lex.advance
@@ -240,7 +243,7 @@ template requireMoreNumberChars() =
   if not lex.readable:
     error errNumberExpected
 
-proc scanSign(lex: var JsonLexer): JsonSign
+func scanSign(lex: var JsonLexer): JsonSign
     {.gcsafe, raises: [].} =
   # Returns None, Pos, or Neg
   # If a sign character is present, it must be followed
@@ -254,9 +257,9 @@ proc scanSign(lex: var JsonLexer): JsonSign
     lex.advance
     return JsonSign.Pos
 
-  return JsonSign.None
+  JsonSign.None
 
-proc scanSign[T](lex: var JsonLexer, val: var T, onlyNeg = false)
+func scanSign[T](lex: var JsonLexer, val: var T, onlyNeg = false)
     {.gcsafe, raises: [].} =
 
   when T isnot (string or JsonVoid or JsonSign):
@@ -342,7 +345,7 @@ proc scanInt[T](lex: var JsonLexer, val: var T,
 # Constructors
 # ------------------------------------------------------------------------------
 
-proc init*(T: type JsonLexer,
+func init*(T: type JsonLexer,
            stream: InputStream,
            flags: JsonReaderFlags = defaultJsonReaderFlags,
            conf: JsonReaderConf = defaultJsonReaderConf): T =
@@ -361,10 +364,10 @@ proc init*(T: type JsonLexer,
 func isErr*(lex: JsonLexer): bool =
   lex.err != errNone
 
-proc col*(lex: JsonLexer): int =
+func col*(lex: JsonLexer): int =
   lex.stream.pos - lex.lineStartPos
 
-proc tokenStartCol*(lex: JsonLexer): int =
+func tokenStartCol*(lex: JsonLexer): int =
   1 + lex.tokenStart - lex.lineStartPos
 
 proc nonws*(lex: var JsonLexer): char {.gcsafe, raises: [IOError].} =
@@ -524,6 +527,33 @@ proc scanString*[T](lex: var JsonLexer, val: var T, limit: int)
   lex.advance
 
   while true:
+    when nimvm:
+      discard  # copyMem unavailable in VM
+    else:
+      let avail = lex.stream.span.len
+      if avail > 0:
+        let base = makeUncheckedArray(lex.stream.span.startAddr)
+        var i = 0
+        while i < avail and base[i] != byte('"') and base[i] != byte('\\') and
+              base[i] >= 0x20'u8:
+          inc i
+        if i > 0:
+          # Honor the string-length limit exactly as the per-char path does:
+          # copy the portion of the run that fits, then raise.
+          var take = i
+          let hitLimit = limit > 0 and strLen + take > limit
+          if hitLimit:
+            take = limit - strLen
+          if take > 0:
+            when T is string:
+              let old = val.len
+              val.setLen(old + take)
+              copyMem(addr val[old], base, take)
+            inc strLen, take
+            lex.stream.span.advance(take)
+          if hitLimit:
+            error errStringLengthLimit
+
     var c = lex.requireNextChar()
     case c
     of '"':

--- a/json_serialization/parser.nim
+++ b/json_serialization/parser.nim
@@ -1,5 +1,5 @@
 # json-serialization
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -14,7 +14,7 @@ import
   ./reader_desc,
   ./lexer
 
-from json import JsonNode, JsonNodeKind, escapeJson, parseJson
+from std/json import JsonNode, JsonNodeKind, escapeJsonUnquoted, parseJson
 
 export
   reader_desc
@@ -48,6 +48,28 @@ template raiseParserError(r: var JsonReader) =
 
 template raiseParserError(r: var JsonReader, err: JsonErrorKind) =
   r.raiseUnexpectedValue($err)
+
+func addEscapedJson(val: var string, s: string) =
+  val.add '"'
+  var scratch = newString(1)
+  var i = 0
+  let n = s.len
+  while i < n:
+    let start = i
+    while i < n and s[i] >= ' ' and s[i] != '"' and s[i] != '\\':
+      inc i
+    if i > start:
+      when nimvm:
+        val.add s[start ..< i]  # copyMem unavailable in VM
+      else:
+        let old = val.len
+        val.setLen(old + (i - start))
+        copyMem(addr val[old], unsafeAddr s[start], i - start)
+    if i < n:
+      scratch[0] = s[i]
+      escapeJsonUnquoted(scratch, val)
+      inc i
+  val.add '"'
 
 # ------------------------------------------------------------------------------
 # Public helpers
@@ -253,7 +275,7 @@ proc parseInt*(r: var JsonReader, T: type SomeInteger, portable: bool = false): 
     r.raiseParserError(errInvalidInt)
   r.toInt(val, T, portable)
 
-proc toFloat*(r: var JsonReader, val: JsonNumber, T: type SomeFloat): T
+func toFloat*(r: var JsonReader, val: JsonNumber, T: type SomeFloat): T
       {.raises: [JsonReaderError].}=
   const
     powersOfTen = [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
@@ -292,7 +314,7 @@ proc parseAsString*(r: var JsonReader, val: var string)
        {.raises: [IOError, JsonReaderError].} =
   case r.tokKind
   of JsonValueKind.String:
-    escapeJson(r.parseString(), val)
+    val.addEscapedJson(r.parseString())
   of JsonValueKind.Number:
     r.lex.scanNumber(val)
     r.checkError
@@ -305,7 +327,7 @@ proc parseAsString*(r: var JsonReader, val: var string)
     do: # comma action
       val.add ','
     do: # key action
-      escapeJson(r.parseString(), val)
+      val.addEscapedJson(r.parseString())
     do: # value action
       val.add ':'
       r.parseAsString(val)

--- a/json_serialization/parser.nim
+++ b/json_serialization/parser.nim
@@ -63,7 +63,13 @@ func addEscapedJson(val: var string, s: string) =
         val.add s[start ..< i]  # copyMem unavailable in VM
       else:
         let old = val.len
-        val.setLen(old + (i - start))
+        # https://github.com/nim-lang/Nim/pull/24836
+        # https://github.com/nim-lang/Nim/pull/25767
+        when (NimMajor, NimMinor, NimPatch) < (2, 2, 10) or
+             ((NimMajor, NimMinor) < (2, 4) and defined(gcRefc)):
+          val.setLen(old + (i - start))
+        else:
+          val.setLenUninit(old + (i - start))
         copyMem(addr val[old], unsafeAddr s[start], i - start)
     if i < n:
       scratch[0] = s[i]

--- a/json_serialization/parser.nim
+++ b/json_serialization/parser.nim
@@ -15,6 +15,7 @@ import
   ./lexer
 
 from std/json import JsonNode, JsonNodeKind, escapeJsonUnquoted, parseJson
+from stew/shims/struninit import setLenUninit2
 
 export
   reader_desc
@@ -63,13 +64,7 @@ func addEscapedJson(val: var string, s: string) =
         val.add s[start ..< i]  # copyMem unavailable in VM
       else:
         let old = val.len
-        # https://github.com/nim-lang/Nim/pull/24836
-        # https://github.com/nim-lang/Nim/pull/25767
-        when (NimMajor, NimMinor, NimPatch) < (2, 2, 10) or
-             ((NimMajor, NimMinor) < (2, 4) and defined(gcRefc)):
-          val.setLen(old + (i - start))
-        else:
-          val.setLenUninit(old + (i - start))
+        val.setLenUninit2(old + (i - start))
         copyMem(addr val[old], unsafeAddr s[start], i - start)
     if i < n:
       scratch[0] = s[i]


### PR DESCRIPTION
Proximately motivated by https://github.com/ethpandaops/benchmarkoor and `nimbus-eth1`, though generally useful for many `nim-json-serialization` users.

`zero_byte_True` speed increases range from 1.85x (1M gas target) to ~2.3x (30+M gas targets). `zero_byte_False` similarly reaches ~2.3x faster at 30+M gas targets, with 10M gas reaching ~1.8x.

The actual JSON decoding for "pure" JSON by 5x, 3% escape-density by 3.5x, and retains performance parity through 25% of the content being escaped.

Other improvements (generally, it's because `newPayload` has to JSON-decode these, and they're all fairly large inputs; pure EVM-computation heavy things aren't helped much):
```
  2.16x  test_bls12_381.py::test_bls12_g2_msm[fork_Osaka-blockchain_test_engine_x-k_64-benchmark-gas-value_10M]
  2.06x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_False-empty_account-transfer_amount_1-case_id_a_to_a-benchmark-gas-value_10M]
  2.05x  test_bls12_381.py::test_bls12_g1_msm[fork_Osaka-blockchain_test_engine_x-k_128-benchmark-gas-value_10M]
  1.86x  test_system.py::test_contract_calling_many_addresses[fork_Osaka-blockchain_test_engine_x-access_warm_True-opcode_CALLCODE-transfer_amount_1-benchmark-gas-value_10M]
  1.84x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_False-non_empty_account-transfer_amount_0-case_id_a_to_a-benchmark-gas-value_10M]
  1.80x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_256-mem_size_1024-opcode_LOG0-benchmark-gas-value_10M]
  1.80x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_True-empty_account-transfer_amount_0-case_id_a_to_a-benchmark-gas-value_10M]
  1.72x  test_transaction_types.py::test_block_full_data[fork_Osaka-blockchain_test_engine_x-zero_byte_False-benchmark-gas-value_10M]
  1.70x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_True-non_empty_account-transfer_amount_1-case_id_a_to_a-benchmark-gas-value_10M]
  1.69x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_True-non_empty_account-transfer_amount_0-case_id_a_to_a-benchmark-gas-value_10M]
  1.68x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_False-non_empty_account-transfer_amount_1-case_id_a_to_a-benchmark-gas-value_10M]
  1.67x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_32-mem_size_1024-opcode_LOG1-benchmark-gas-value_10M]
  1.66x  test_transaction_types.py::test_ether_transfers[fork_Osaka-blockchain_test_engine_x-warm_access_False-delegated_account-transfer_amount_0-case_id_a_to_diff_acc-benchmark-gas-value_10M]
  1.65x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_256-mem_size_1024-opcode_LOG1-benchmark-gas-value_10M]
  1.64x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_1024-mem_size_256-opcode_LOG2-benchmark-gas-value_10M]
  1.61x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_32-mem_size_1024-opcode_LOG3-benchmark-gas-value_10M]
  1.59x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_32-mem_size_256-opcode_LOG1-benchmark-gas-value_10M]
  1.59x  test_log.py::test_log[fork_Osaka-blockchain_test_engine_x-fixed_offset_True-zeros_topic-1_MiB_zeros_data-opcode_LOG0-benchmark-gas-value_10M]
  1.59x  test_log.py::test_log_benchmark[fork_Osaka-blockchain_test_engine_x-log_size_256-mem_size_256-opcode_LOG0-benchmark-gas-value_10M]
  1.58x  test_transaction_types.py::test_block_full_data[fork_Osaka-blockchain_test_engine_x-zero_byte_True-benchmark-gas-value_10M]
```